### PR TITLE
add 'show fps' setting

### DIFF
--- a/Kontroloj/Agordoj.gd
+++ b/Kontroloj/Agordoj.gd
@@ -8,7 +8,8 @@ func _ready():
 	Agordejo.load(agordejo)
 	get_node("Sonoj").set_pressed(Agordejo.get_value("Agordoj", "Sonoj", true))
 	get_node("Muzikoj").set_pressed(Agordejo.get_value("Agordoj", "Muzikoj", true))
-
+	get_node("ShowFPS").set_pressed(Agordejo.get_value("Settings", "show_fps", false))
+	
 func _notification(what):
 	if what == MainLoop.NOTIFICATION_WM_QUIT_REQUEST:
 		get_tree().change_scene("res://Kontroloj/Niveloj.tscn")
@@ -19,6 +20,10 @@ func _on_Sonoj_toggled( b ):
 
 func _on_Muzikoj_toggled( b ):
 	Agordejo.set_value("Agordoj", "Muzikoj", b)
+	Agordejo.save(agordejo)
+	
+func _on_ShowFPS_toggled( b ):
+	Agordejo.set_value("Settings", "show_fps", b)
 	Agordejo.save(agordejo)
 
 func _on_Reen_pressed():

--- a/Kontroloj/Agordoj.tscn
+++ b/Kontroloj/Agordoj.tscn
@@ -28,9 +28,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 50.0
-margin/top = 250.0
+margin/top = 75.0
 margin/right = 400.0
-margin/bottom = 350.0
+margin/bottom = 175.0
 custom_fonts/font = ExtResource( 2 )
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_colors/font_color_hover = Color( 0, 0, 0, 1 )
@@ -51,9 +51,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 50.0
-margin/top = 500.0
+margin/top = 325.0
 margin/right = 400.0
-margin/bottom = 600.0
+margin/bottom = 425.0
 custom_fonts/font = ExtResource( 2 )
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_colors/font_color_hover = Color( 0, 0, 0, 1 )
@@ -63,6 +63,28 @@ is_pressed = true
 enabled_focus_mode = 2
 shortcut = null
 text = "Muzikoj"
+flat = false
+align = 0
+
+[node name="ShowFPS" type="CheckButton" parent="."]
+
+rect/scale = Vector2( 2, 2 )
+focus/ignore_mouse = false
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 50.0
+margin/top = 575.0
+margin/right = 402.0
+margin/bottom = 675.0
+custom_fonts/font = ExtResource( 2 )
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+custom_colors/font_color_hover = Color( 0, 0, 0, 1 )
+custom_colors/font_color_pressed = Color( 0, 0, 0, 1 )
+toggle_mode = true
+enabled_focus_mode = 2
+shortcut = null
+text = "Show FPS"
 flat = false
 align = 0
 
@@ -96,6 +118,8 @@ flat = false
 [connection signal="toggled" from="Sonoj" to="." method="_on_Sonoj_toggled"]
 
 [connection signal="toggled" from="Muzikoj" to="." method="_on_Muzikoj_toggled"]
+
+[connection signal="toggled" from="ShowFPS" to="." method="_on_ShowFPS_toggled"]
 
 [connection signal="pressed" from="Reen" to="." method="_on_Reen_pressed"]
 

--- a/Radiko.gd
+++ b/Radiko.gd
@@ -45,7 +45,9 @@ func _ready():
 	get_tree().set_auto_accept_quit(false)
 	Agordejo.load(agordejo)
 	get_node("Fonmuziko").set("stream/play", Agordejo.get_value("Agordoj", "Muzikoj", true))
-
+	
+	show_hide_fps()
+	
 	var epoko = Tutmonda.epoko
 
 	if epoko == "nova":
@@ -321,3 +323,14 @@ func _on_vastigu_la_reton_pressed():
 		get_node("Reto/N4").show()
 		reto = 4
 
+func show_hide_fps():
+	if Agordejo == null:
+		return
+	Agordejo.load(agordejo)
+	if Agordejo.get_value("Settings", "show_fps", false):
+		FPS.show()
+	else:
+		FPS.hide()
+		
+func _enter_tree():
+	show_hide_fps()


### PR DESCRIPTION
Adds a new CheckButton control in the settings "Show FPS", which enables/toggles the FPS display in the game. Defaults to false and is saved in the config file.

Needs translations?

Implements  #33.